### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Major-Updates sollten wir wahrscheinlich immer manuell machen - meldet euch gerne hier, wenn ihr das anders seht

Aktueller Anlass: https://github.com/freenet-actions/setup-aws-cli/pull/564